### PR TITLE
Fix usage example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ const str = '\tunicorn\n\t\tcake';
 		cake
 */
 
-minIndent(str); // 2
+minIndent(str); // 1
 ```
 
 


### PR DESCRIPTION
The example had me confused until I tried it in RunKit:


<img width="395" alt="runkit outputs 1" src="https://user-images.githubusercontent.com/1402241/32403730-78ce316e-c10f-11e7-81a2-0e258d7b3ac5.png"> <img width="260" alt="" src="https://user-images.githubusercontent.com/1402241/32403719-2cfbb91e-c10f-11e7-850b-571c9367cae8.png">