### PR TITLE
Use more efficient minimum length construction

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,5 @@ module.exports = str => {
 	}
 
 	// TODO: Use spread operator when targeting Node.js 6
-	return Math.min.apply(Math, match.map(x => x.length));
+	return match.reduce((r, a) => Math.min(r, a.length), Infinity);
 };


### PR DESCRIPTION
The current `Math.min.apply` construction throws `RangeError: Maximum call stack size exceeded` on semi-large files. Here's where we ran in to the issue: https://github.com/sveltejs/svelte-preprocess/issues/143

It's more efficient to use `arr.reduce` instead.